### PR TITLE
content: agentic mobile QA with Claude or Codex (PT/EN)

### DIFF
--- a/priv/posts/en/2026/09-03-your-next-qa-agent-validating-apps-in-the-simulator.md
+++ b/priv/posts/en/2026/09-03-your-next-qa-agent-validating-apps-in-the-simulator.md
@@ -1,0 +1,359 @@
+%{
+  title: "Your Next QA Teammate Could Be an Agent: Validating Apps in the Simulator with Claude or Codex",
+  author: "Iago Cavalcante",
+  tags: ~w(ai qa testing mobile claude codex mcp simulators automation),
+  description: "How to connect Claude or Codex to a simulator, turn requirements into executable scenarios, and build a mobile QA loop with evidence, logs, and regression tests.",
+  locale: "en",
+  published: false
+}
+---
+
+Hey, everyone!
+
+You know that moment when you finish a mobile feature, run the test suite, see everything green, and still open the app to check it “one more time”?
+
+You log in. Tap three buttons. Go back one screen. Change the language. Close and reopen the app. Turn on airplane mode. By the time you notice, you have spent half an hour repeating a checklist that exists only in your head.
+
+That is when I started looking at Claude and Codex differently.
+
+Instead of using an agent only to write code, why not give it access to the simulator and ask it to validate the app the way a QA engineer would?
+
+I do not mean sending a prompt like “test my app” and trusting a reply that says “everything looks fine.” The interesting part is building a loop where the agent can:
+
+1. Build and launch the application
+2. Read the screen's accessibility tree
+3. Tap, type, scroll, and navigate
+4. Capture screenshots and logs
+5. Compare the result against acceptance criteria
+6. Fix the problem and repeat the exact same flow
+
+This changes the development dynamic quite a bit. The agent is no longer just the one implementing the feature. It also becomes the one trying to prove that the implementation works.
+
+In this article, I will walk through a general strategy for doing that. It works for native apps, React Native, Flutter, or any other stack that can run on an iOS Simulator or Android Emulator.
+
+## The Problem Is Not a Lack of Tests
+
+Almost every mobile project has some level of automated testing.
+
+We have unit tests for business rules, integration tests for APIs, and, in some cases, end-to-end tests with Maestro, Detox, or Appium.
+
+Even then, plenty of bugs still slip through:
+
+- a button is hidden by the keyboard
+- the session disappears after restarting the app
+- a loading state never ends when the API fails
+- a translated string breaks the layout
+- the back button opens the wrong screen
+- a permission is denied and the app does not explain how to continue
+- the feature works in isolation but fails in the user's real flow
+
+This happens because there is still a gap between “the code passed its tests” and “a person was able to use the app.”
+
+QA in the simulator helps close that gap. A coding agent is particularly useful here because it can observe both sides at once: the interface that failed and the code that produced it.
+
+## The Agent Needs Eyes, Hands, and Memory
+
+Claude and Codex cannot magically control your application on their own. They need tools.
+
+You can think of the setup as three layers:
+
+```text
+Claude or Codex
+      |
+      | prompt + acceptance criteria
+      v
+MCP, skill, or terminal commands
+      |
+      | build, snapshot, tap, type, swipe, logs
+      v
+iOS Simulator or Android Emulator
+```
+
+On iOS, an MCP server such as XcodeBuildMCP can expose builds, app launches, screenshots, the UI hierarchy, logs, and the debugger to the agent. OpenAI has an official [Codex and iOS Simulator use case](https://learn.chatgpt.com/use-cases/ios-simulator-bug-debugging) that follows this kind of workflow.
+
+With Claude Code, the [Model Context Protocol](https://docs.anthropic.com/en/docs/mcp) connects external tools to the agent. That tool can be an existing MCP server or a small internal server that wraps the commands your project already uses.
+
+On Android, you can build the same idea on top of `adb`, UI Automator, Maestro, or another driver that can inspect and control the emulator.
+
+The tool's name matters less than its contract. The agent needs a small set of operations that it can perform reliably:
+
+```text
+build_app
+boot_device
+install_app
+launch_app
+read_ui_tree
+tap_element
+type_text
+swipe
+take_screenshot
+read_logs
+reset_app_state
+```
+
+It looks simple, but this list is already enough to validate a large part of an app.
+
+## Do Not Start with “Test Everything”
+
+This is probably the worst possible prompt:
+
+```text
+Test my entire application and fix any problems you find.
+```
+
+The agent does not know what “entire” means. It also does not know which data it can create, which account it should use, which screens are critical, or when a visual difference is actually a bug.
+
+A good QA run starts with a scenario, an initial state, and an expected result.
+
+For example:
+
+```text
+Validate the password recovery flow on an iPhone 16 running iOS 26.
+
+Preconditions:
+- use the qa@example.com account
+- start with the app signed out
+- do not send real emails
+
+Acceptance criteria:
+- an invalid email shows an inline field error
+- a valid email opens the confirmation screen
+- returning to login preserves the typed email
+- no unexpected errors appear in the logs
+
+Deliver:
+- steps performed
+- screenshots of important states
+- the result of each acceptance criterion
+- logs related to any failure
+- files changed if a fix is required
+```
+
+Now there is a verifiable contract.
+
+The agent knows where to begin, what it is allowed to do, and which evidence it needs to deliver.
+
+## The Loop I Use
+
+A reliable agent-driven QA flow has six stages.
+
+### 1. Prepare a Known State
+
+Before testing, the agent needs to know whether it should clear the app, preserve a session, or load a fixture.
+
+Without that instruction, the same scenario may pass in one run and fail in the next simply because the simulator kept old data.
+
+Some useful options are:
+
+- uninstall and reinstall the app
+- clear test storage and keychain data
+- use dedicated QA accounts
+- reset the local database
+- start a fake API with known responses
+- open the app through a specific deep link
+
+The goal is not to erase everything every time. The goal is to make the initial state explicit.
+
+### 2. Confirm the Screen Before Interacting
+
+The agent should capture a screenshot or read the UI tree before the first tap.
+
+This prevents a common failure: trying to tap a button using coordinates that belonged to the previous screen.
+
+Whenever the interface changes, the agent reads the hierarchy again.
+
+It is also worth adding `accessibilityLabel`, `accessibilityIdentifier`, `testID`, or the equivalent in your stack to important elements. Coordinates break when the device size changes. Semantic identifiers survive.
+
+### 3. Perform One Action at a Time
+
+The agent acts, observes the result, and only then continues.
+
+```text
+read screen
+  -> tap “Sign in”
+  -> read new screen
+  -> enter email
+  -> read form state
+  -> submit
+  -> capture result
+```
+
+This cadence may look slower, but it saves time when something fails. You know exactly which action changed the state.
+
+### 4. Collect Evidence While the Bug Is Happening
+
+A screenshot helps, but not every bug is visual.
+
+A good run can combine:
+
+- screenshots before and after the action
+- the accessibility tree
+- application logs
+- requests and responses from the test API
+- a crash stack trace
+- persisted device state
+- a short video of the flow when useful
+
+The goal is to move from “it failed” to “it failed after this action, in this state, with this log.”
+
+### 5. Make the Smallest Possible Fix
+
+If the agent can also edit the project, it should reproduce the failure before touching the code.
+
+That order makes all the difference.
+
+Without reproduction, the agent may fix a hypothesis. With reproduction, it can compare the behavior before and after the change.
+
+I also keep the scope small: one bug per run. Mixing login, notifications, layout, and caching in a single run makes it difficult to know which change solved which problem.
+
+### 6. Repeat the Same Path
+
+After the fix, compiling is not enough.
+
+The agent should reset the necessary state and repeat the path that failed. Same account. Same device. Same steps. Same acceptance criteria.
+
+At the end, I want a report that looks like this:
+
+```text
+Device: iPhone 16, iOS 26.0
+Build: a1b2c3d
+Scenario: password recovery
+
+PASS - invalid email shows an inline error
+PASS - valid email opens confirmation
+PASS - returning to login preserves the email
+PASS - no unexpected errors in the logs
+
+Evidence:
+- artifacts/password-invalid.png
+- artifacts/password-confirmation.png
+- artifacts/simulator.log
+```
+
+Now we have evidence, not just confidence.
+
+## Build a Small, Useful Matrix
+
+Validating every combination of device, operating system, and state is not practical. The trick is choosing a matrix that represents real risk.
+
+I would start with this:
+
+| Area | Minimum scenario |
+| --- | --- |
+| Onboarding | first launch, skip, and complete |
+| Authentication | successful login, error, and logout |
+| Core flow | the path that delivers the app's main value |
+| Persistence | close, reopen, and restore state |
+| Permissions | allow, deny, and try again |
+| Network | offline, timeout, and invalid response |
+| Layout | small device, larger font, and another language |
+| Navigation | back, deep link, and returning from background |
+
+You do not need to run everything on every commit.
+
+The critical happy path can run all the time. Error scenarios and the visual matrix can run before a release or whenever the corresponding area changes.
+
+## Turn Discoveries into Regression Tests
+
+This is my favorite part of the flow.
+
+An agent is good at exploration. It can inspect the screen, interpret an unusual state, and decide which path to try next.
+
+But we should not spend LLM reasoning on repeating the same login forever.
+
+Once a scenario becomes stable, turn it into a deterministic test using the project's E2E tool.
+
+```text
+agent explores
+  -> finds a bug
+  -> reproduces it with evidence
+  -> fixes it
+  -> writes a regression test
+  -> CI repeats it without an LLM
+```
+
+The agent discovers. The automated test protects.
+
+This split keeps the cost predictable and reduces flakiness. It also prevents Claude or Codex from becoming an expensive robot that keeps clicking through the same screens.
+
+## Put the Rules in the Repository
+
+If every session needs to relearn how to test your app, you still have a manual process.
+
+Document the rules in `AGENTS.md`, `CLAUDE.md`, or a project skill.
+
+Here is a simple example:
+
+```markdown
+## Mobile QA
+
+- Always use the qa@example.com account.
+- Never run destructive flows in production.
+- Prefer accessibility IDs; do not use coordinates when a selector exists.
+- Save evidence under artifacts/qa/<scenario>/.
+- Record the device, OS, build, and initial state.
+- Reproduce the bug before changing code.
+- Repeat the same flow after the fix.
+- Run one scenario at a time.
+```
+
+You can go further and create commands such as:
+
+```text
+./scripts/qa/reset-app
+./scripts/qa/start-fixtures
+./scripts/qa/collect-logs
+./scripts/qa/run-critical-path
+```
+
+The easier it is to prepare and observe the environment, the better the agent performs.
+
+This does not benefit only AI. A new person on the team can also reproduce the scenario without depending on tribal knowledge.
+
+## Where the Simulator Is Not Enough
+
+There is one important limit: a simulator is not a real device.
+
+I would not use this flow as the only validation for:
+
+- push notifications delivered through APNs or FCM
+- camera, microphone, Bluetooth, and NFC
+- real biometrics
+- battery and memory consumption
+- performance on entry-level devices
+- behavior on an unstable cellular network
+- store purchases and subscriptions
+- background execution controlled by the operating system
+- differences between Android manufacturers
+
+The simulator is great for navigation, states, forms, layout, persistence, and many integration failures. For physical capabilities or system-specific behavior, we still need a canary run on a real device.
+
+I would not remove human review either. An agent can prove that a button works, but it cannot decide on its own whether the experience is clear, pleasant, and consistent with the product.
+
+## The Practical Result
+
+When this loop works, you are not getting an “artificial QA” that replaces a person.
+
+You are getting a low-cost way to remove repetitive work from the team's head.
+
+The developer describes the expected behavior. The agent prepares the simulator, performs the flow, collects evidence, and points to where the contract broke. If it is allowed to fix the problem, it makes the smallest change and repeats the same path.
+
+Then the important scenario becomes a deterministic regression test.
+
+It is a simple combination:
+
+```text
+unit tests guarantee rules
+integration tests guarantee contracts
+E2E guarantees known flows
+the agent explores what has not become a test yet
+a real device validates what the simulator cannot represent
+```
+
+No single layer solves everything. Together, they make a release much less dependent on someone saying, “open it quickly and see if it works.”
+
+That is it, folks!
+
+If you have already connected Claude or Codex to a simulator, tell me how you built your loop. Reach out on [Twitter](https://x.com/iagoangelimc) or [LinkedIn](https://linkedin.com/in/iago-a-cavalcante).
+
+Ready to test it?

--- a/priv/posts/pt_BR/2026/09-03-qa-com-claude-codex-validando-app-no-simulador.md
+++ b/priv/posts/pt_BR/2026/09-03-qa-com-claude-codex-validando-app-no-simulador.md
@@ -1,0 +1,359 @@
+%{
+  title: "Seu Próximo QA Pode Ser um Agente: Validando Apps no Simulador com Claude ou Codex",
+  author: "Iago Cavalcante",
+  tags: ~w(ai qa testes mobile claude codex mcp simuladores automacao),
+  description: "Como conectar Claude ou Codex ao simulador, transformar requisitos em cenários executáveis e criar um loop de QA mobile com evidências, logs e testes de regressão.",
+  locale: "pt_BR",
+  published: false
+}
+---
+
+Fala, pessoal!
+
+Sabe quando você termina uma feature mobile, roda os testes, vê tudo verde e mesmo assim abre o app para conferir “só mais uma vez”?
+
+Você faz login. Toca em três botões. Volta uma tela. Troca o idioma. Fecha e abre o app. Ativa o modo avião. Quando percebe, passou meia hora repetindo um roteiro que está só na sua cabeça.
+
+Foi aí que comecei a olhar para Claude e Codex de outro jeito.
+
+Em vez de usar o agente apenas para escrever código, por que não dar a ele acesso ao simulador e pedir para validar o app como um QA faria?
+
+Não estou falando de mandar um prompt como “teste meu app” e confiar num “parece tudo certo”. A parte interessante é montar um loop em que o agente consegue:
+
+1. Compilar e abrir o aplicativo
+2. Ler a árvore de acessibilidade da tela
+3. Tocar, digitar, rolar e navegar
+4. Capturar screenshots e logs
+5. Comparar o resultado com critérios de aceite
+6. Corrigir o problema e repetir exatamente o mesmo fluxo
+
+Isso muda bastante a dinâmica do desenvolvimento. O agente deixa de ser apenas quem implementa e passa a ser também quem tenta provar que a implementação funciona.
+
+Neste artigo vou mostrar uma estratégia genérica para fazer isso. Serve para apps nativos, React Native, Flutter ou qualquer stack que consiga rodar em um iOS Simulator ou Android Emulator.
+
+## O Problema Não É a Falta de Testes
+
+Quase todo projeto mobile tem algum nível de teste automatizado.
+
+Temos unit tests para regras de negócio, integration tests para API e, em alguns casos, testes end-to-end com Maestro, Detox ou Appium.
+
+Mesmo assim, vários bugs continuam escapando:
+
+- um botão ficou escondido pelo teclado
+- a sessão sumiu depois de reiniciar o app
+- o loading não termina quando a API falha
+- o texto em português quebra o layout
+- o botão de voltar abre a tela errada
+- a permissão foi negada e o app não explica como continuar
+- a feature funciona isolada, mas falha no fluxo real do usuário
+
+Isso acontece porque existe um espaço entre “o código passou nos testes” e “uma pessoa conseguiu usar o app”.
+
+O QA no simulador ajuda a fechar esse espaço. E um coding agent é particularmente útil porque consegue observar os dois lados ao mesmo tempo: a interface que falhou e o código que produziu aquela interface.
+
+## O Agente Precisa de Olhos, Mãos e Memória
+
+Claude ou Codex, sozinhos, não controlam magicamente seu aplicativo. Eles precisam de ferramentas.
+
+Podemos pensar em três camadas:
+
+```text
+Claude ou Codex
+      |
+      | prompt + critérios de aceite
+      v
+MCP, skill ou comandos de terminal
+      |
+      | build, snapshot, tap, type, swipe, logs
+      v
+iOS Simulator ou Android Emulator
+```
+
+No iOS, um MCP como o XcodeBuildMCP pode expor build, launch, screenshots, UI hierarchy, logs e debugger para o agente. A própria OpenAI possui um [caso de uso do Codex no iOS Simulator](https://learn.chatgpt.com/use-cases/ios-simulator-bug-debugging) seguindo esse fluxo.
+
+No Claude Code, o [Model Context Protocol](https://docs.anthropic.com/en/docs/mcp) permite conectar ferramentas externas ao agente. Essa ferramenta pode ser um MCP pronto ou um servidor pequeno do seu time que encapsula os comandos usados no projeto.
+
+No Android, a mesma ideia pode ser construída em cima de `adb`, UI Automator, Maestro ou outro driver que consiga inspecionar e controlar o emulator.
+
+O nome da ferramenta importa menos do que o contrato. O agente precisa conseguir realizar um conjunto pequeno de operações de forma confiável:
+
+```text
+build_app
+boot_device
+install_app
+launch_app
+read_ui_tree
+tap_element
+type_text
+swipe
+take_screenshot
+read_logs
+reset_app_state
+```
+
+Parece bobeira, mas essa lista já é suficiente para validar boa parte de um app.
+
+## Não Comece com “Teste Tudo”
+
+O pior prompt possível é este:
+
+```text
+Teste todo o meu aplicativo e corrija qualquer problema.
+```
+
+O agente não sabe o que “todo” significa. Também não sabe quais dados pode criar, qual conta deve usar, quais telas são críticas ou quando uma diferença visual é realmente um bug.
+
+Um bom run de QA começa com um cenário, um estado inicial e um resultado esperado.
+
+Por exemplo:
+
+```text
+Valide o fluxo de recuperação de senha no iPhone 16 com iOS 26.
+
+Pré-condições:
+- use a conta qa@example.com
+- comece com o app sem sessão
+- não envie e-mails reais
+
+Critérios de aceite:
+- um e-mail inválido mostra erro no próprio campo
+- um e-mail válido abre a tela de confirmação
+- voltar para o login preserva o e-mail digitado
+- nenhum erro inesperado aparece nos logs
+
+Entregue:
+- passos executados
+- screenshots dos estados importantes
+- resultado de cada critério
+- logs relacionados a qualquer falha
+- arquivos alterados, caso uma correção seja necessária
+```
+
+Agora existe um contrato verificável.
+
+O agente sabe onde começar, o que pode fazer e qual evidência precisa entregar.
+
+## O Loop Que Eu Uso
+
+Um fluxo confiável de QA com agente possui seis etapas.
+
+### 1. Preparar um Estado Conhecido
+
+Antes de testar, o agente precisa saber se deve limpar o aplicativo, manter uma sessão ou carregar uma fixture.
+
+Sem isso, o mesmo cenário pode passar numa execução e falhar na próxima apenas porque o simulador guardou dados antigos.
+
+Algumas opções úteis:
+
+- desinstalar e instalar o app novamente
+- limpar storage e keychain de teste
+- usar contas exclusivas de QA
+- resetar o banco local
+- iniciar uma API fake com respostas conhecidas
+- abrir o app por um deep link específico
+
+O ponto não é sempre apagar tudo. É tornar o estado inicial explícito.
+
+### 2. Confirmar a Tela Antes de Interagir
+
+O agente deve capturar um screenshot ou ler a árvore de UI antes do primeiro toque.
+
+Isso evita um erro comum: tentar tocar em um botão usando coordenadas que pertenciam à tela anterior.
+
+Sempre que a interface mudar, o agente lê a hierarquia novamente.
+
+Também vale muito a pena adicionar `accessibilityLabel`, `accessibilityIdentifier`, `testID` ou o equivalente da sua stack nos elementos importantes. Coordenadas quebram quando muda o tamanho do aparelho. Identificadores semânticos sobrevivem.
+
+### 3. Executar Uma Ação por Vez
+
+O agente toca, observa o resultado e só então continua.
+
+```text
+ler tela
+  -> tocar em “Entrar”
+  -> ler nova tela
+  -> preencher e-mail
+  -> ler estado do formulário
+  -> enviar
+  -> capturar resultado
+```
+
+Essa cadência parece mais lenta, mas economiza tempo quando alguma coisa falha. Você sabe exatamente qual ação mudou o estado.
+
+### 4. Coletar Evidência Enquanto o Bug Acontece
+
+Screenshot ajuda, mas nem todo bug é visual.
+
+Um bom run pode combinar:
+
+- screenshot antes e depois
+- árvore de acessibilidade
+- logs do aplicativo
+- requests e responses da API de teste
+- stack trace de crash
+- estado persistido no device
+- vídeo curto do fluxo, quando fizer sentido
+
+O objetivo é sair de “deu erro” para “deu erro depois desta ação, neste estado, com este log”.
+
+### 5. Fazer a Menor Correção Possível
+
+Se o agente também pode editar o projeto, ele deve primeiro reproduzir a falha e só depois mexer no código.
+
+Essa ordem faz toda diferença.
+
+Sem reprodução, ele pode corrigir uma hipótese. Com reprodução, ele consegue comparar antes e depois.
+
+Também peço para manter o escopo pequeno: um bug por execução. Misturar login, notificações, layout e cache no mesmo run torna difícil saber qual mudança resolveu qual problema.
+
+### 6. Repetir o Mesmo Caminho
+
+Depois da correção, não basta compilar.
+
+O agente deve resetar o estado necessário e repetir o roteiro que falhou. Mesma conta. Mesmo aparelho. Mesmos passos. Mesmos critérios de aceite.
+
+No final, quero uma resposta parecida com esta:
+
+```text
+Device: iPhone 16, iOS 26.0
+Build: a1b2c3d
+Scenario: recuperação de senha
+
+PASS - e-mail inválido mostra erro inline
+PASS - e-mail válido abre confirmação
+PASS - voltar preserva o e-mail
+PASS - nenhum erro inesperado nos logs
+
+Evidence:
+- artifacts/password-invalid.png
+- artifacts/password-confirmation.png
+- artifacts/simulator.log
+```
+
+Agora temos evidência, não só confiança.
+
+## Monte uma Matriz Pequena e Útil
+
+Validar todas as combinações de device, sistema operacional e estado é inviável. O segredo é escolher uma matriz que represente risco real.
+
+Eu começaria assim:
+
+| Área | Cenário mínimo |
+| --- | --- |
+| Onboarding | primeira abertura, pular e concluir |
+| Autenticação | login válido, erro e logout |
+| Fluxo principal | caminho que entrega o valor central do app |
+| Persistência | fechar, reabrir e recuperar o estado |
+| Permissões | permitir, negar e tentar novamente |
+| Rede | offline, timeout e resposta inválida |
+| Layout | aparelho pequeno, fonte maior e outro idioma |
+| Navegação | back, deep link e retorno do background |
+
+Não precisa executar tudo em todo commit.
+
+O happy path crítico pode rodar sempre. Cenários de erro e matriz visual podem rodar antes de release ou quando a área correspondente mudar.
+
+## Transforme Descobertas em Regressão
+
+Aqui está a parte que mais gosto desse fluxo.
+
+O agente é bom em exploração. Ele consegue olhar a tela, interpretar um estado estranho e decidir qual caminho tentar depois.
+
+Mas não devemos gastar raciocínio de LLM para sempre repetir o mesmo login.
+
+Quando um cenário estabiliza, transforme-o em um teste determinístico com a ferramenta de E2E do projeto.
+
+```text
+agente explora
+  -> encontra bug
+  -> reproduz com evidência
+  -> corrige
+  -> escreve teste de regressão
+  -> CI repete sem LLM
+```
+
+O agente descobre. O teste automatizado protege.
+
+Essa divisão deixa o custo previsível e reduz flakiness. Também evita transformar Claude ou Codex num robô caro clicando sempre nas mesmas telas.
+
+## Coloque as Regras no Repositório
+
+Se toda sessão precisa reaprender como testar seu app, você ainda tem um processo manual.
+
+Documente as regras em `AGENTS.md`, `CLAUDE.md` ou numa skill do projeto.
+
+Um exemplo simples:
+
+```markdown
+## QA mobile
+
+- Use sempre a conta qa@example.com.
+- Nunca rode fluxos destrutivos em produção.
+- Prefira accessibility IDs; não use coordenadas quando existir um seletor.
+- Salve evidências em artifacts/qa/<cenario>/.
+- Registre device, OS, build e estado inicial.
+- Reproduza o bug antes de alterar código.
+- Depois da correção, repita o mesmo fluxo.
+- Um cenário por execução.
+```
+
+Você pode ir além e criar comandos como:
+
+```text
+./scripts/qa/reset-app
+./scripts/qa/start-fixtures
+./scripts/qa/collect-logs
+./scripts/qa/run-critical-path
+```
+
+Quanto mais fácil for preparar e observar o ambiente, melhor o agente trabalha.
+
+Isso não beneficia só a IA. Uma pessoa nova no time também consegue reproduzir o cenário sem depender de conhecimento tribal.
+
+## Onde o Simulador Não É Suficiente
+
+Tem mais, mas existe um limite importante: simulador não é aparelho real.
+
+Eu não usaria esse fluxo como única validação para:
+
+- push notification entregue por APNs ou FCM
+- câmera, microfone, Bluetooth e NFC
+- biometria real
+- consumo de bateria e memória
+- performance em aparelhos de entrada
+- comportamento com rede móvel instável
+- compra e assinatura nas lojas
+- background execution controlado pelo sistema
+- diferenças de fabricante no Android
+
+O simulador cobre muito bem navegação, estados, formulários, layout, persistência e vários erros de integração. Para capacidades físicas ou comportamento específico do sistema, ainda precisamos de canário em device real.
+
+Também não eliminaria revisão humana. O agente consegue provar que um botão funciona, mas não decide sozinho se a experiência é clara, agradável ou coerente com o produto.
+
+## O Resultado Prático
+
+Quando esse loop funciona, você não ganha um “QA artificial” que substitui uma pessoa.
+
+Você ganha uma forma barata de tirar trabalho repetitivo da cabeça do time.
+
+O desenvolvedor descreve o comportamento esperado. O agente prepara o simulador, executa o fluxo, coleta evidência e aponta onde o contrato quebrou. Se puder corrigir, faz a menor mudança e repete o mesmo caminho.
+
+Depois, o cenário importante vira regressão determinística.
+
+É uma composição simples:
+
+```text
+unit tests garantem regras
+integration tests garantem contratos
+E2E garante fluxos conhecidos
+agente explora o que ainda não virou teste
+device real valida o que o simulador não representa
+```
+
+Nenhuma camada resolve tudo. Juntas, elas deixam o release muito menos dependente daquele “abre aí rapidinho e vê se está funcionando”.
+
+É isso, pessoal!
+
+Se você já conectou Claude ou Codex ao simulador, me conta como montou seu loop. Me chama no [Twitter](https://x.com/iagoangelimc) ou no [LinkedIn](https://linkedin.com/in/iago-a-cavalcante).
+
+Bora testar?


### PR DESCRIPTION
## Resumo

Adiciona versões em português e inglês de um novo artigo sobre como usar Claude ou Codex como uma camada de QA para apps mobile no simulador.

O texto cobre:

- arquitetura de ferramentas via MCP, skills ou CLI
- loop `reset -> inspect -> act -> assert -> evidence -> rerun`
- prompt reutilizável com critérios de aceite
- matriz mínima de cenários mobile
- separação entre exploração por agente e regressão determinística
- limites do simulador e gate em device físico

Os dois posts estão como `published: false` para revisão editorial.

## Arquivos

- `priv/posts/pt_BR/2026/09-03-qa-com-claude-codex-validando-app-no-simulador.md`
- `priv/posts/en/2026/09-03-your-next-qa-agent-validating-apps-in-the-simulator.md`

## Validação

- `NimblePublisher` encontrou e compilou os dois posts com locales `pt_BR` e `en`
- o conteúdo Markdown foi convertido para HTML
- `git diff --check` passou
- o teste de blog compilou a aplicação, mas não executou porque o PostgreSQL local rejeitou a senha configurada (`FATAL 28P01`), um problema de ambiente sem relação com os posts

## Referências técnicas

- caso de uso oficial do Codex para iOS Simulator
- documentação oficial do MCP no Claude Code