### PR TITLE
content: publish agentic mobile QA articles

### DIFF
--- a/priv/posts/en/2026/09-03-your-next-qa-agent-validating-apps-in-the-simulator.md
+++ b/priv/posts/en/2026/09-03-your-next-qa-agent-validating-apps-in-the-simulator.md
@@ -4,7 +4,7 @@
   tags: ~w(ai qa testing mobile claude codex mcp simulators automation),
   description: "How to connect Claude or Codex to a simulator, turn requirements into executable scenarios, and build a mobile QA loop with evidence, logs, and regression tests.",
   locale: "en",
-  published: false
+  published: true
 }
 ---
 

--- a/priv/posts/pt_BR/2026/09-03-qa-com-claude-codex-validando-app-no-simulador.md
+++ b/priv/posts/pt_BR/2026/09-03-qa-com-claude-codex-validando-app-no-simulador.md
@@ -4,7 +4,7 @@
   tags: ~w(ai qa testes mobile claude codex mcp simuladores automacao),
   description: "Como conectar Claude ou Codex ao simulador, transformar requisitos em cenários executáveis e criar um loop de QA mobile com evidências, logs e testes de regressão.",
   locale: "pt_BR",
-  published: false
+  published: true
 }
 ---
 


### PR DESCRIPTION
## Summary

Publishes the English and Portuguese versions of the agentic mobile QA article by setting `published: true`.

## Validation

- both posts are returned by `Iagocavalcante.Blog.published_posts/0`
- locales validated as `en` and `pt_BR`
- `git diff --check` passed